### PR TITLE
Add graal to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,9 +98,7 @@ jobs:
           - "pypy-3.9"
           - "pypy-3.10"
           # - "pypy-3.11"
-          # don't enable graal because it's slower than even pypy and
-          # fails because oracle/graalpython#385
-          # - "graalpy-23"
+          - "graalpy-24"
         include:
           - source: sdist
             artifact: dist/*.tar.gz


### PR DESCRIPTION
Graal was previously added commented as a placeholder because it was way too slow.

Add a draft PR with an up-to-date graal version, so we can track how slow it is (or if it’s gotten faster).